### PR TITLE
Add alignment title property

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -52,7 +52,7 @@
                   uiOptions: {
                     hidePopupOnClickAway: false
                   },
-                  disabledClass: 'alpheios-disabled',
+                  
                   desktopTriggerEvent: 'click',
                   triggerPreCallback: detectCtrl
                 }).activate();

--- a/src/lib/controllers/download-controller.js
+++ b/src/lib/controllers/download-controller.js
@@ -51,9 +51,9 @@ export default class DownloadController {
    * @param {Object} data - all data for download
    * @return {Boolean} - true - download was done, false - not
    */
-  static download (downloadType, data) {
+  static download (downloadType, data, fileName) {
     if (this.downloadMethods[downloadType]) {
-      return this.downloadMethods[downloadType].method(data)
+      return this.downloadMethods[downloadType].method(data, fileName)
     }
     console.error(L10nSingleton.getMsgS('DOWNLOAD_CONTROLLER_ERROR_TYPE', { downloadType }))
     NotificationSingleton.addNotification({
@@ -69,7 +69,7 @@ export default class DownloadController {
    * @param {Object} data - all data for download
    * @return {Boolean} - true - download was done, false - not
    */
-  static plainSourceDownloadAll (data) {
+  static plainSourceDownloadAll (data, fileName) {
     if (!data.originDocSource || !data.targetDocSources) {
       console.error(L10nSingleton.getMsgS('DOWNLOAD_CONTROLLER_ERROR_NO_TEXTS'))
       NotificationSingleton.addNotification({
@@ -96,9 +96,9 @@ export default class DownloadController {
     })
 
     const now = NotificationSingleton.timeNow.bind(new Date())()
-    const fileName = `${now}-alignment-${data.originDocSource.lang}-${langs.join('-')}`
+    const finalFileName = fileName || `${now}-alignment-${data.originDocSource.lang}-${langs.join('-')}`
     const exportFields = ['header', 'direction', 'lang', 'sourceType']
-    return DownloadFileCSV.download(fields, exportFields, fileName)
+    return DownloadFileCSV.download(fields, exportFields, finalFileName)
   }
 
   /**
@@ -128,7 +128,7 @@ export default class DownloadController {
     return DownloadFileCSV.download(fields, exportFields, fileName)
   }
 
-  static jsonSimpleDownloadAll (data) {
+  static jsonSimpleDownloadAll (data, fileName) {
     let langs = [] // eslint-disable-line prefer-const
 
     Object.values(data.targets).forEach(target => {
@@ -138,11 +138,11 @@ export default class DownloadController {
     const now = NotificationSingleton.timeNow.bind(new Date())()
 
     const filePrefixName = data.origin.alignedText ? 'full-alignment' : 'alignment'
-    const fileName = `${now}-${filePrefixName}-${data.origin.docSource.lang}-${langs.join('-')}`
-    return DownloadFileJSON.download(data, fileName)
+    const finalFileName = fileName || `${now}-${filePrefixName}-${data.origin.docSource.lang}-${langs.join('-')}`
+    return DownloadFileJSON.download(data, finalFileName)
   }
 
-  static htmlDownloadAll (data) {
+  static htmlDownloadAll (data, fileName) {
     const htmlTemplate = HTMLTemplateJSON
     let layout = htmlTemplate.layout
 
@@ -156,7 +156,7 @@ export default class DownloadController {
 
     const now = NotificationSingleton.timeNow.bind(new Date())()
 
-    const fileName = `${now}-alignment-html-output-${data.langs.join('-')}`
-    return DownloadFileHTML.download(layout, fileName)
+    const finalFileName = fileName || `${now}-alignment-html-output-${data.langs.join('-')}`
+    return DownloadFileHTML.download(layout, finalFileName)
   }
 }

--- a/src/lib/controllers/texts-controller.js
+++ b/src/lib/controllers/texts-controller.js
@@ -18,8 +18,8 @@ export default class TextsController {
    * @param {String} originDocSource
    * @param {String} targetDocSource
    */
-  createAlignment () {
-    this.alignment = new Alignment()
+  createAlignment (alTitle) {
+    this.alignment = new Alignment({ title: alTitle })
     return this.alignment
   }
 
@@ -28,6 +28,10 @@ export default class TextsController {
    */
   get couldStartAlign () {
     return Boolean(this.alignment) && this.alignment.readyForTokenize
+  }
+
+  get alignmentTitle () {
+    return this.alignment && this.alignment.title
   }
 
   /**
@@ -356,7 +360,7 @@ export default class TextsController {
    * Prepares and download source data
    * @returns {Boolean} - true - download was successful, false - was not
    */
-  async downloadData (downloadType, additional = {}) {
+  async downloadData (downloadType, additional = {}, fileName) {
     const downloadPrepareMethods = {
       plainSourceDownloadAll: this.downloadShortData.bind(this),
       jsonSimpleDownloadAll: this.downloadFullData.bind(this),
@@ -364,7 +368,7 @@ export default class TextsController {
     }
 
     const result = await downloadPrepareMethods[downloadType](downloadType, additional)
-    await DownloadController.download(result.downloadType, result.data)
+    await DownloadController.download(result.downloadType, result.data, fileName)
     return true
   }
 

--- a/src/lib/data/alignment.js
+++ b/src/lib/data/alignment.js
@@ -22,7 +22,7 @@ import ConvertUtility from '@/lib/utility/convert-utility.js'
 export default class Alignment {
   /**
    */
-  constructor ({ id, createdDT, updatedDT, userID } = {}) {
+  constructor ({ id, createdDT, updatedDT, userID, title } = {}) {
     this.id = id || uuidv4()
     this.createdDT = createdDT || new Date()
 
@@ -49,6 +49,8 @@ export default class Alignment {
     this.tokensEditActions = new TokensEditActions({ origin: this.origin, targets: this.targets, tokensEditHistory: this.tokensEditHistory })
 
     this.tokensEditHistory.allStepActions = this.allStepActionsTokensEditor
+
+    this.title = title || `Project ${this.id}`
   }
 
   static get defaultUserID () {
@@ -1229,6 +1231,7 @@ export default class Alignment {
       createdDT: ConvertUtility.convertDateToString(this.createdDT),
       updatedDT: ConvertUtility.convertDateToString(this.updatedDT),
       userID: this.userID,
+      title: this.title,
       origin,
       targets,
       alignmentGroups,
@@ -1244,7 +1247,7 @@ export default class Alignment {
     const createdDT = ConvertUtility.convertStringToDate(data.createdDT)
     const updatedDT = ConvertUtility.convertStringToDate(data.updatedDT)
     const alignment = new Alignment({
-      id: data.id, createdDT, updatedDT, userID: data.userID
+      id: data.id, createdDT, updatedDT, userID: data.userID, title: data.title
     })
 
     alignment.origin.docSource = SourceText.convertFromJSON('origin', data.origin.docSource)
@@ -1433,6 +1436,7 @@ export default class Alignment {
       updatedDT: ConvertUtility.convertDateToString(this.updatedDT),
       userID: this.userID,
       langsList: this.langsList,
+      title: this.title,
       hasTokens,
       origin,
       targets,
@@ -1446,7 +1450,7 @@ export default class Alignment {
     const updatedDT = ConvertUtility.convertStringToDate(dbData.updatedDT)
 
     const alignment = new Alignment({
-      id: dbData.alignmentID, createdDT, updatedDT, userID: dbData.userID
+      id: dbData.alignmentID, createdDT, updatedDT, userID: dbData.userID, title: dbData.title
     })
 
     if (dbData.docSource) {

--- a/src/lib/storage/indexed-db-structure.js
+++ b/src/lib/storage/indexed-db-structure.js
@@ -174,7 +174,8 @@ export default class IndexedDBStructure {
       createdDT: data.createdDT,
       updatedDT: data.updatedDT,
       langsList: data.langsList,
-      hasTokens: data.hasTokens
+      hasTokens: data.hasTokens,
+      title: data.title
     }]
   }
 

--- a/src/locales/en-us/messages-initial-screen.json
+++ b/src/locales/en-us/messages-initial-screen.json
@@ -4,6 +4,11 @@
       "description": "Button on initial screen",
       "component": "InitialScreen"
     },
+    "INITIAL_NEW_ALIGNMENT_TITLE": {
+      "message": "Define Project Name",
+      "description": "Popup Header",
+      "component": "CreateAlTitlePopup"
+    },
     "INITIAL_RESUME_ALIGNMENT": {
       "message": "Resume previous alignment",
       "description": "Button on initial screen",

--- a/src/vue/align-editor/actions-menu-align-editor.vue
+++ b/src/vue/align-editor/actions-menu-align-editor.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="alpheios-alignment-editor-actions-menu">
+    <div class="alpheios-alignment-editor-actions-menu" data-alpheios-ignore="all">
       <div class="alpheios-alignment-editor-actions-menu__buttons">
         <button class="alpheios-editor-button-tertiary alpheios-actions-menu-button  alpheios-disabled"  id="alpheios-actions-menu-align-editor-button__undo"
             @click="undoAction" :disabled="!undoAvailable" >

--- a/src/vue/alignments-list.vue
+++ b/src/vue/alignments-list.vue
@@ -7,7 +7,7 @@
             {{ alData.updatedDT }}
           </td>
           <td class="alpheios-alignment-editor-alignments-table_link" @click="uploadAlignmentFromDB(alData)">
-            {{ alData.langsList }}
+            {{ alData.title || alData.langsList }}
           </td>
           <td class="alpheios-alignment-editor-alignments-table_link" @click="uploadAlignmentFromDB(alData)">
             {{ formatHasTokens(alData.hasTokens) }}

--- a/src/vue/app.vue
+++ b/src/vue/app.vue
@@ -36,6 +36,8 @@
       <waiting-popup @closeModal = "$modal.hide('waiting')" />
 
       <upload-warn-popup @closeModal = "$modal.hide('upload-warn')" :updatedDTInDB = "updatedDTInDB" @continue-upload = "continueUpload" />
+
+      <create-al-title-popup @create-alignment = "createANewAlignment" @closeModal = "$modal.hide('create-al-title')" />
   </div>
 </template>
 <script>
@@ -49,6 +51,7 @@ import SummaryPopup from '@/vue/summary-popup.vue'
 
 import WaitingPopup from '@/vue/common/waiting-popup.vue'
 import UploadWarnPopup from '@/vue/common/upload-warn-popup.vue'
+import CreateAlTitlePopup from '@/vue/common/create-al-title-popup.vue'
 
 import NotificationBar from '@/vue/notification-bar.vue'
 import TextEditor from '@/vue/text-editor/text-editor.vue'
@@ -74,8 +77,8 @@ export default {
     initialScreen: InitialScreen,
     summaryPopup: SummaryPopup,
     waitingPopup: WaitingPopup,
-    uploadWarnPopup: UploadWarnPopup
-
+    uploadWarnPopup: UploadWarnPopup,
+    createAlTitlePopup: CreateAlTitlePopup
   },
   data () {
     return {     
@@ -221,7 +224,11 @@ export default {
     },
 
     startNewInitialAlignment () {
-      this.$textC.createAlignment()
+      this.$modal.show('create-al-title')
+    },
+
+    createANewAlignment (alTitle) {
+      this.$textC.createAlignment(alTitle)
       this.$historyAGC.startTracking(this.$textC.alignment)
       this.showSourceTextEditor()
     },

--- a/src/vue/common/create-al-title-popup.vue
+++ b/src/vue/common/create-al-title-popup.vue
@@ -1,0 +1,82 @@
+<template>
+    <modal classes="alpheios-alignment-editor-modal-create-al-title" name="create-al-title" :draggable="true" height="auto" :shiftY="0.3">
+        <div class="alpheios-modal-header">
+          <span class="alpheios-alignment-modal-close-icon" @click="$emit('closeModal')">
+              <x-close-icon />
+          </span>
+          <h2 class="alpheios-alignment-editor-modal-header">{{ l10n.getMsgS('INITIAL_NEW_ALIGNMENT_TITLE') }}</h2>
+        </div>
+        <div class="alpheios-modal-body">
+            <p class="alpheios-alignment-editor-file-name-value">
+              <input
+                  class="alpheios-alignment-input alpheios-file-name-value"
+                  type="text"
+                  v-model="alTitle"
+                  id="alTitleId"
+                  @keyup.enter = "createAlignment"
+              >
+            </p>
+        </div>
+        <div class="alpheios-modal-footer" >
+          <div class="alpheios-editor-summary-footer" >
+            <button class="alpheios-editor-button-tertiary alpheios-actions-menu-button" @click = "createAlignment" :disabled="!alTitle">{{ l10n.getMsgS('INITIAL_NEW_ALIGNMENT') }}</button>
+            <button class="alpheios-editor-button-tertiary alpheios-actions-menu-button" @click = "$emit('closeModal')" >{{ l10n.getMsgS('UPLOAD_WARN_CANCEL_BUTTON') }}</button>
+          </div>
+        </div>
+    </modal>
+</template>
+<script>
+import XCloseIcon from '@/inline-icons/x-close.svg'
+import L10nSingleton from '@/lib/l10n/l10n-singleton.js'
+
+export default {
+  name: 'CreateAlTitlePopup',
+  components: {
+    xCloseIcon: XCloseIcon
+  },
+  props: {
+  },
+  data () {
+    return {
+      alTitle: null
+    }
+  },
+  computed: {
+    l10n () {
+      return L10nSingleton
+    }
+  },
+  methods: {
+    createAlignment () {
+      if (this.alTitle && (this.alTitle.length > 0)) {
+        this.$emit('create-alignment', this.alTitle)
+        this.$emit('closeModal')
+      }
+    }
+  }
+}
+</script>
+<style lang="scss">
+  .alpheios-alignment-editor-modal-create-al-title {
+    .alpheios-modal-header {
+      border: 0;
+      h2 {
+        margin: 0;
+        text-align: center;
+      }
+    }
+    .alpheios-modal-body {
+      border: 0;
+      padding: 10px 0;
+
+      p {
+        text-align: center;
+        padding: 20px 50px 20px;
+        margin: 0;
+      }
+      input {
+        
+      }
+    }
+  }
+</style>

--- a/src/vue/common/save-popup.vue
+++ b/src/vue/common/save-popup.vue
@@ -1,5 +1,5 @@
 <template>
-    <modal :classes="classes" :name="mname" :draggable="true" height="auto" @before-open="beforeOpen">
+    <modal :classes="classes" :name="mname" :draggable="true" height="auto" @before-open="beforeOpen" data-alpheios-ignore="all">
         <div class="alpheios-modal-header" >
           <span class="alpheios-alignment-modal-close-icon" @click="$emit('closeModal')">
               <x-close-icon />
@@ -14,6 +14,15 @@
                     <label :for="downloadTypeId(dType.name)">{{ dType.label }}</label>
                   </tooltip>
               </span>
+            </p>
+            <p class="alpheios-alignment-editor-file-name-value">
+              <input
+                  class="alpheios-alignment-input alpheios-file-name-value"
+                  type="text"
+                  v-model="fileName"
+                  id="fileNameId"
+                  @keyup.enter = "downloadData"
+              >
             </p>
         </div>
         <div class="alpheios-modal-footer" >
@@ -30,6 +39,7 @@ import DownloadController from '@/lib/controllers/download-controller.js'
 import Tooltip from '@/vue/common/tooltip.vue'
 
 import SettingsController from '@/lib/controllers/settings-controller.js'
+import NotificationSingleton from '@/lib/notifications/notification-singleton'
 
 export default {
   name: 'SavePopup',
@@ -46,7 +56,8 @@ export default {
   },
   data () {
     return {
-      currentDownloadType: null
+      currentDownloadType: null,
+      fileName: null
     }
   },
 
@@ -61,14 +72,24 @@ export default {
     },
     classes () {
       return `alpheios-alignment-editor-modal-${this.mname}`
+    },
+    titleName () {
+      return this.$store.state.alignmentUpdated && this.$textC.alignmentTitle
     }
   },
   methods: {
     beforeOpen (event) {
+      /*
       if (this.downloadTypes.length === 1) {
         this.downloadData()
         event.cancel()
       }
+      */
+     if (!this.fileName) {
+       const now = NotificationSingleton.timeNow.bind(new Date())()
+       this.fileName = `${now}-${ this.titleName }`
+     }
+     
     },
     downloadTypeId (dTypeName) {
       return `alpheios-save-popup-download-block__radio_${dTypeName}`
@@ -81,7 +102,7 @@ export default {
           theme: SettingsController.themeOptionValue
         }
       }
-      await this.$textC.downloadData(this.currentDownloadType, additional)
+      await this.$textC.downloadData(this.currentDownloadType, additional, this.fileName)
       
     }
   }

--- a/src/vue/text-editor/metadata-block.vue
+++ b/src/vue/text-editor/metadata-block.vue
@@ -1,5 +1,5 @@
 <template>
-  <modal :classes="classes" :name="mname"  :draggable="true" height="auto">
+  <modal :classes="classes" :name="mname"  :draggable="true" height="auto" data-alpheios-ignore="all">
     <div class="alpheios-modal-header" >
         <span class="alpheios-alignment-modal-close-icon" @click = "$emit('closeModal')">
             <x-close-icon />

--- a/tests/lib/controllers/download-controller.test.js
+++ b/tests/lib/controllers/download-controller.test.js
@@ -71,9 +71,9 @@ describe('download-controller.test.js', () => {
     }
     
     jest.spyOn(DownloadController, 'plainSourceDownloadAll')
-    DownloadController.download(downloadType, data)
+    DownloadController.download(downloadType, data, 'testFileName')
 
-    expect(DownloadController.plainSourceDownloadAll).toHaveBeenCalledWith(data)
+    expect(DownloadController.plainSourceDownloadAll).toHaveBeenCalledWith(data, 'testFileName')
   })
 
   it('4 DownloadController - static plainSourceDownloadAll method prints error if data is not correctly defined ', () => {


### PR DESCRIPTION
For the issue https://github.com/alpheios-project/alignment-editor-new/issues/749

- added title property for alignment
- define it on Begin new alignment - inside specific popup
![image](https://user-images.githubusercontent.com/12377640/164233479-f68f78ce-197c-4305-9e28-08feb6cb7fd5.png)

- add file input to Saving popup - constructed trom title propety
- it is saved during session

- it is saved in IndexedDB and json file

For the issue https://github.com/alpheios-project/alignment-editor-new/issues/746

- set enableAnnotations option to true by default 
- remove enableAnnotations option from Options

![image](https://user-images.githubusercontent.com/12377640/164235554-f3353fce-b75d-498c-8d64-b9d397540c11.png)
