### PR TITLE
Fix begin new alignment in the menu (was not uploaded in previous PR)

### DIFF
--- a/src/settings/default-app-settings.json
+++ b/src/settings/default-app-settings.json
@@ -168,7 +168,7 @@
       ]
     },
     "enableAnnotations": {
-      "defaultValue": false,
+      "defaultValue": true,
       "labelText": "Annotating",
       "boolean": true,
       "values": [

--- a/src/vue/app.vue
+++ b/src/vue/app.vue
@@ -11,6 +11,7 @@
         @undo-action = "undoAction"
         @add-target = "addTarget"
         @clear-all = "startOver"
+        @new-initial-alignment = "startNewInitialAlignment"
 
         @showOptions = "showOptions"
         @showSourceTextEditor = "showSourceTextEditor"

--- a/src/vue/main-menu.vue
+++ b/src/vue/main-menu.vue
@@ -37,7 +37,7 @@
           
           <button class="alpheios-app-menu-link" id ="alpheios-main-menu-clear-all" 
                   @click="clearAll">
-                  {{ l10n.getMsgS('MAIN_MENU_CLEAR_TEXT') }}
+                  {{ l10n.getMsgS('INITIAL_NEW_ALIGNMENT') }}
           </button>
         </div>
       </div>
@@ -179,8 +179,10 @@ export default {
       this.showUploadBlock = false
       this.showDownloadBlock = false
       this.$emit('clear-all')
+
       this.currentPage = 'initial-page'
       this.closeMenu()
+      this.$emit("new-initial-alignment")
     },
     
     closeMenu () {

--- a/src/vue/options/options-text-align.vue
+++ b/src/vue/options/options-text-align.vue
@@ -9,8 +9,8 @@
     </div>
     <div class="alpheios-modal-body" >
       <div class="alpheios-alignment-editor-modal-options-block">
-        <option-item-block :optionItem = "enableAnnotationsOptionItem" :optionInfo="getOptionInfo('enableAnnotations')" />        
-
+         <option-item-block :optionItem = "enableAnnotationsOptionItem" :optionInfo="getOptionInfo('enableAnnotations')" />
+         
         <fieldset v-show = "enableAnnotationsValue" class="alpheios-alignment-editor-modal-options-block-fieldset">
           <option-item-block :optionItem = "availableAnnotationTypesOptionItem"  :disabled = "disableAnnotationsTypes" />
           <option-item-block :optionItem = "maxCharactersAnnotationTextOptionItem" />


### PR DESCRIPTION
For the issue https://github.com/alpheios-project/alignment-editor-new/issues/749

- update menu item name to Begin new alignment
- redirect on the main event on Initial screen

For the issue https://github.com/alpheios-project/alignment-editor-new/issues/746

- set Enable annotations to true by default