### PR TITLE
Divide filename definition to two parts - date and name

### DIFF
--- a/src/lib/controllers/texts-controller.js
+++ b/src/lib/controllers/texts-controller.js
@@ -34,6 +34,13 @@ export default class TextsController {
     return this.alignment && this.alignment.title
   }
 
+  updateAlignmentTitle (title) {
+    const result = this.alignment && this.alignment.updateAlignmentTitle(title)
+    this.store.commit('incrementAlignmentUpdated')
+    StorageController.update(this.alignment)
+    return result
+  }
+
   /**
    * Checks if the length of all source texts are not out of the limit, defined by the settings
    * @returns

--- a/src/lib/data/alignment.js
+++ b/src/lib/data/alignment.js
@@ -57,6 +57,10 @@ export default class Alignment {
     return 'defaultUserID'
   }
 
+  updateAlignmentTitle (title) {
+    this.title = title
+  }
+
   get langsList () {
     let strResult
     if (!this.origin.docSource) { return '' }

--- a/src/vue/common/save-popup.vue
+++ b/src/vue/common/save-popup.vue
@@ -144,13 +144,15 @@ export default {
     }
   }
 
-  .alpheios-alignment-input.alpheios-file-name-date-value {
-    display: inline-block;
-    width: 100px;
-  }
+  .alpheios-alignment-editor-file-name-value {
+    .alpheios-alignment-input.alpheios-file-name-date-value {
+      display: inline-block;
+      width: 100px;
+    }
 
-  .alpheios-alignment-input.alpheios-file-name-title-value {
-    display: inline-block;
-    width: calc(100% - 110px);
+    .alpheios-alignment-input.alpheios-file-name-title-value {
+      display: inline-block;
+      width: calc(100% - 110px);
+    }
   }
 </style>

--- a/src/vue/common/save-popup.vue
+++ b/src/vue/common/save-popup.vue
@@ -17,10 +17,17 @@
             </p>
             <p class="alpheios-alignment-editor-file-name-value">
               <input
-                  class="alpheios-alignment-input alpheios-file-name-value"
+                  class="alpheios-alignment-input alpheios-file-name-date-value"
                   type="text"
-                  v-model="fileName"
-                  id="fileNameId"
+                  v-model="fileNameDate"
+                  id="fileNameDateId"
+                  :disabled = "true"
+              >
+              <input
+                  class="alpheios-alignment-input alpheios-file-name-title-value"
+                  type="text"
+                  v-model="fileNameTitle"
+                  id="fileNameTitleId"
                   @keyup.enter = "downloadData"
               >
             </p>
@@ -57,6 +64,8 @@ export default {
   data () {
     return {
       currentDownloadType: null,
+      fileNameDate: null,
+      fileNameTitle: null,
       fileName: null
     }
   },
@@ -79,22 +88,19 @@ export default {
   },
   methods: {
     beforeOpen (event) {
-      /*
-      if (this.downloadTypes.length === 1) {
-        this.downloadData()
-        event.cancel()
-      }
-      */
-     if (!this.fileName) {
-       const now = NotificationSingleton.timeNow.bind(new Date())()
-       this.fileName = `${now}-${ this.titleName }`
-     }
-     
+      const now = NotificationSingleton.timeNow.bind(new Date())()
+      this.fileNameDate = now
+      
+      this.fileNameTitle = this.titleName     
     },
     downloadTypeId (dTypeName) {
       return `alpheios-save-popup-download-block__radio_${dTypeName}`
     },
     async downloadData () {
+      this.$textC.updateAlignmentTitle(this.fileNameTitle)
+
+      this.fileName = `${ this.fileNameDate }-${ this.fileNameTitle }`
+
       this.$emit('closeModal')
       let additional = {}
       if (this.currentDownloadType === 'htmlDownloadAll') {
@@ -136,5 +142,15 @@ export default {
     .alpheios-alignment-editor-modal-header {
       margin-bottom: 10px;
     }
+  }
+
+  .alpheios-alignment-input.alpheios-file-name-date-value {
+    display: inline-block;
+    width: 100px;
+  }
+
+  .alpheios-alignment-input.alpheios-file-name-title-value {
+    display: inline-block;
+    width: calc(100% - 110px);
   }
 </style>


### PR DESCRIPTION
For the issue https://github.com/alpheios-project/alignment-editor-new/issues/758

- defined two fields:
   - date (each saving it is re-generated )
   - project name (a user could update it here and it would be saved and used for IndexedDB autosaved)
   
![image](https://user-images.githubusercontent.com/12377640/165879228-53c420d4-ae1e-4acc-a09d-5f1576b94b38.png)

![image](https://user-images.githubusercontent.com/12377640/165879248-e0965edf-8934-4e58-9ef7-dbf6cdce70c5.png)