### PR TITLE
Updated css - enter text or choose a file to one line

### DIFF
--- a/src/vue/text-editor/text-editor-single-block.vue
+++ b/src/vue/text-editor/text-editor-single-block.vue
@@ -14,7 +14,7 @@
           </tooltip>
         </span>
       </p>
-      <div v-show="showTypeUploadButtons" >
+      <div class="alpheios-alignment-editor-text-blocks-single__first-line" v-show="showTypeUploadButtons" >
         <span class="alpheios-alignment-editor-text-blocks-single__type-label">{{ l10n.getMsgS('TEXT_SINGLE_TYPE_LABEL') }}</span>
         <button class="alpheios-editor-button-tertiary alpheios-actions-menu-button"  id="alpheios-actions-menu-button__uploadtext"
             @click="selectUploadText" v-show="enableDTSAPIUploadValue">
@@ -70,12 +70,10 @@
 
 
       <div class="alpheios-alignment-editor-text-blocks-single__describe-button" >
-        <tooltip :tooltipText="l10n.getMsgS('DESCRIBE_BUTTON_TOOLTIP')" tooltipDirection="top">
           <button class="alpheios-editor-button-tertiary alpheios-actions-menu-button"  :id="describeButtonId"
               @click="$modal.show(metadataModalName)" :disabled="!isMetadataAvailable" >
               {{ l10n.getMsgS('DESCRIBE_BUTTON_TITLE') }}
           </button>
-        </tooltip>
       </div>
   </div>
 </template>
@@ -766,5 +764,10 @@ export default {
   .alpheios-alignment-editor-text-blocks-single__describe-button {
     text-align: center;
     margin-top: 10px;
+  }
+
+  .alpheios-alignment-editor-text-blocks-single__first-line,
+  .alpheios-alignment-editor-actions-menu__upload-block {
+    display: inline-block;
   }
 </style>


### PR DESCRIPTION
For the issue https://github.com/alpheios-project/alignment-editor-new/issues/798

- updated css for enter text line
![image](https://user-images.githubusercontent.com/12377640/169183187-f22120f4-4b28-4f38-b3d6-5c28d0733369.png)

- removed tooltip from Describe buttons